### PR TITLE
Optimize PyTelTools reading/writing

### DIFF
--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -35,8 +35,8 @@ def selafin(f):
 @PERF 
 def telemac(f):
     tel = TelemacFile(f)
-    for i_var in range(len(tel.varnames)):
-        tel.get_data_value(i_var, 10)
+    for varname in tel.varnames:
+        tel.get_data_value(varname, 10)
 
 # ppUtils
 @timer

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -35,7 +35,8 @@ def selafin(f):
 @PERF 
 def telemac(f):
     tel = TelemacFile(f)
-    tel.get_data_value(tel.varnames[0], 10)
+    for i_var in range(len(tel.varnames)):
+        tel.get_data_value(i_var, 10)
 
 # ppUtils
 @timer
@@ -50,6 +51,6 @@ def ppUtils(f):
 @PERF
 def pyTelTools(f):
     with Serafin.Read(f, 'en') as resin:
-        resin.read_header()  # fills resin.header (read mesh)
-        resin.get_time()
-        resin.read_var_in_frame(10,resin.header.var_IDs[0])
+        resin.read_header()  # fills resin.header (reads mesh)
+        # resin.get_time()  # fills resin.time but not compulsory here
+        resin.read_vars_in_frame(10)  # read all variables of a specific record


### PR DESCRIPTION
Here is an update of **PyTelTools** which uses `np.frombuffer` and `np.ndarray.tobytes` for arrays reading/writing.
It gives a _significant speedup_ (at least x10).

I also fixed (but not tested) **TelemacFile** reading to read _all_ variables of the same record.

As I do not have **manda** and uses Python 3.12, I am not able to update easily the benchmark values. Could you please do it?